### PR TITLE
Save query result history

### DIFF
--- a/main.js
+++ b/main.js
@@ -44,17 +44,14 @@ form.addEventListener('submit', function (event) {
   score += 5
   updateScore()
 
-  displayText.innerHTML = ''
-  queryHistory.forEach((query, index) => {
-    displayText.innerHTML +=
-      '<p>Query ' + (index + 1) + ': ' + query.replace(/\n/g, '<br>') + '</p>'
-  })
-
-  scrollToBottom()
+  const index = queryHistory.length - 1
+  displayText.innerHTML +=
+    '<p>Query ' + (index + 1) + ': ' + query.replace(/\n/g, '<br>') + '</p>'
 
   textarea.value = ''
 
-  executeQuery(query, queryHistory.length - 1)
+  scrollToBottom()
+  executeQuery(query, index)
 })
 
 function executeQuery (query, index) {
@@ -109,8 +106,10 @@ function executeQuery (query, index) {
         const queryElement = displayText.querySelectorAll('p')[index]
         queryElement.insertAdjacentElement('afterend', resultsElement)
 
+        scrollToBottom()
         db.close()
       })
+
       .catch(error => {
         console.error('Error fetching the SQLite file:', error)
       })

--- a/styles.css
+++ b/styles.css
@@ -55,6 +55,7 @@ body {
 
 .display-text {
   height: 70vh;
+  padding-right: 15px;
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--main-color) transparent;


### PR DESCRIPTION
This PR allows the query result history to be saved. Prior to this PR, when a new query was entered after the previous query's result was displayed, the result would get overwritten and only the queries would show. This PR fixes this and ensures that the entire prior history is visible, both for queries and their associated results.