### PR TITLE
Add Extra Space Between Query Results for Improved Readability

### DIFF
--- a/main.js
+++ b/main.js
@@ -104,6 +104,7 @@ function executeQuery (query, index, queryWrapper) {
           displayError(queryWrapper, errorMessage)
         }
         db.close()
+        queryWrapper.appendChild(document.createElement('br'))
         scrollToBottom()
       })
       .catch(error => {


### PR DESCRIPTION
This PR addresses #28 by adding the necessary  'br'  element to the queryWrapper after displaying the query result which creates an extra line break between the results of different queries. This makes it easier to differentiate between the results and improves readability.