### PR TITLE
Fix unresponsive main game screen

### DIFF
--- a/storyScript.js
+++ b/storyScript.js
@@ -90,6 +90,10 @@ function beginGame () {
             setTimeout(() => {
               newFadeToBlackDiv.style.opacity = '0'
             }, 1000)
+
+            setTimeout(() => {
+              newFadeToBlackDiv.style.visibility = 'hidden'
+            }, 2000)
           }
         }
       })


### PR DESCRIPTION
This PR fixes the issue of the main game screen not being responsive after the transition from the story screen. The issue was occurring due to the fade-to-black screen overlaying the entire panel even after the transition is complete. After this fix, the panel gets hidden after the transition and the screen becomes responsive. 